### PR TITLE
add basic formatting and use some variables

### DIFF
--- a/home-lab/config.tf
+++ b/home-lab/config.tf
@@ -9,8 +9,8 @@ terraform {
 
 # Providers
 provider "proxmox" {
-  pm_api_url = "https://192.168.1.120:8006/api2/json"
-  pm_api_token_id="terraform-prov@pve!terraform-prov"
-  pm_debug = true
+  pm_api_url      = "https://192.168.1.120:8006/api2/json"
+  pm_api_token_id = "terraform-prov@pve!terraform-prov"
+  pm_debug        = true
   pm_tls_insecure = true
 }

--- a/home-lab/config.tf
+++ b/home-lab/config.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 1.11.4"
   required_providers {
     proxmox = {
       source  = "Telmate/proxmox"
@@ -9,8 +10,8 @@ terraform {
 
 # Providers
 provider "proxmox" {
-  pm_api_url      = "https://192.168.1.120:8006/api2/json"
-  pm_api_token_id = "terraform-prov@pve!terraform-prov"
+  pm_api_url      = var.proxmox_api_url
+  pm_api_token_id = var.pm_api_token_id
   pm_debug        = true
-  pm_tls_insecure = true
+  pm_tls_insecure = var.pm_tls_insecure
 }

--- a/home-lab/inputs.tf
+++ b/home-lab/inputs.tf
@@ -1,0 +1,4 @@
+variable "proxmox_api_url" {
+  description = "Proxmox URL"
+  type        = string
+}

--- a/home-lab/kubernetes-cluster.tf
+++ b/home-lab/kubernetes-cluster.tf
@@ -29,7 +29,7 @@ resource "proxmox_vm_qemu" "talos-m01" {
     ide {
       ide2 {
         cdrom {
-          iso = "nas-isos:iso/talos-metal-amd64.iso"
+          iso = var.talos_iso
         }
       }
     }
@@ -72,7 +72,7 @@ resource "proxmox_vm_qemu" "talos-m02" {
     ide {
       ide2 {
         cdrom {
-          iso = "nas-isos:iso/talos-metal-amd64.iso"
+          iso = var.talos_iso
         }
       }
     }
@@ -115,7 +115,7 @@ resource "proxmox_vm_qemu" "talos-m03" {
     ide {
       ide2 {
         cdrom {
-          iso = "nas-isos:iso/talos-metal-amd64.iso"
+          iso = var.talos_iso
         }
       }
     }
@@ -158,7 +158,7 @@ resource "proxmox_vm_qemu" "talos-w01" {
     ide {
       ide2 {
         cdrom {
-          iso = "nas-isos:iso/talos-metal-amd64.iso"
+          iso = var.talos_iso
         }
       }
     }
@@ -201,7 +201,7 @@ resource "proxmox_vm_qemu" "talos-w02" {
     ide {
       ide2 {
         cdrom {
-          iso = "nas-isos:iso/talos-metal-amd64.iso"
+          iso = var.talos_iso
         }
       }
     }
@@ -244,7 +244,7 @@ resource "proxmox_vm_qemu" "talos-w03" {
     ide {
       ide2 {
         cdrom {
-          iso = "nas-isos:iso/talos-metal-amd64.iso"
+          iso = var.talos_iso
         }
       }
     }

--- a/home-lab/kubernetes-cluster.tf
+++ b/home-lab/kubernetes-cluster.tf
@@ -2,260 +2,260 @@
 
 # Control Plane 01
 resource "proxmox_vm_qemu" "talos-m01" {
-    name            = "talos-m01"
-    target_node     = "vm-01"
-    agent           = 1
-    memory          = 4096
-    balloon         = 2048
-    # sockets         = 1
-    cores           = 4
-    tags            = "kubernetes,kcp"
+  name        = "talos-m01"
+  target_node = "vm-01"
+  agent       = 1
+  memory      = 4096
+  balloon     = 2048
+  # sockets         = 1
+  cores = 4
+  tags  = "kubernetes,kcp"
 
-    disks {
-      scsi {
-        scsi0 {
-          disk { # Root Disk
-            size        = "20G"
-            storage     = "nas-vdisk"
-          }
-        }
-        scsi1 {
-          disk { # Storage Disk
-            size        = "100G"
-            storage     = "nas-vdisk"
-          }
+  disks {
+    scsi {
+      scsi0 {
+        disk { # Root Disk
+          size    = "20G"
+          storage = "nas-vdisk"
         }
       }
-      ide {
-        ide2 {
-          cdrom {
-            iso = "nas-isos:iso/talos-metal-amd64.iso"
-          }
+      scsi1 {
+        disk { # Storage Disk
+          size    = "100G"
+          storage = "nas-vdisk"
         }
       }
     }
-
-    network { # Primary Interface
-        id          = 0
-        model       = "virtio"
-        bridge      = "vmbr0"
-        firewall    = true
+    ide {
+      ide2 {
+        cdrom {
+          iso = "nas-isos:iso/talos-metal-amd64.iso"
+        }
+      }
     }
+  }
+
+  network { # Primary Interface
+    id       = 0
+    model    = "virtio"
+    bridge   = "vmbr0"
+    firewall = true
+  }
 }
 
 # Control Plane 02
 resource "proxmox_vm_qemu" "talos-m02" {
-    name            = "talos-m02"
-    target_node     = "vm-01" # Set to 'vm-01' while 'vm-02' is in hibernation
-    agent           = 1
-    memory          = 4096
-    balloon         = 2048
-    # sockets         = 1
-    cores           = 4
-    tags            = "kubernetes,kcp"
+  name        = "talos-m02"
+  target_node = "vm-01" # Set to 'vm-01' while 'vm-02' is in hibernation
+  agent       = 1
+  memory      = 4096
+  balloon     = 2048
+  # sockets         = 1
+  cores = 4
+  tags  = "kubernetes,kcp"
 
-    disks {
-      scsi {
-        scsi0 {
-          disk { # Root Disk
-            size        = "20G"
-            storage     = "nas-vdisk"
-          }
-        }
-        scsi1 {
-          disk { # Storage Disk
-            size        = "100G"
-            storage     = "nas-vdisk"
-          }
+  disks {
+    scsi {
+      scsi0 {
+        disk { # Root Disk
+          size    = "20G"
+          storage = "nas-vdisk"
         }
       }
-      ide {
-        ide2 {
-          cdrom {
-            iso = "nas-isos:iso/talos-metal-amd64.iso"
-          }
+      scsi1 {
+        disk { # Storage Disk
+          size    = "100G"
+          storage = "nas-vdisk"
         }
       }
     }
-
-    network { # Primary Interface
-        id          = 0
-        model       = "virtio"
-        bridge      = "vmbr0"
-        firewall    = true
+    ide {
+      ide2 {
+        cdrom {
+          iso = "nas-isos:iso/talos-metal-amd64.iso"
+        }
+      }
     }
+  }
+
+  network { # Primary Interface
+    id       = 0
+    model    = "virtio"
+    bridge   = "vmbr0"
+    firewall = true
+  }
 }
 
 # Control Plane 03
 resource "proxmox_vm_qemu" "talos-m03" {
-    name            = "talos-m03"
-    target_node     = "vm-03"
-    agent           = 1
-    memory          = 4096
-    balloon         = 2048
-    # sockets         = 1
-    cores           = 4
-    tags            = "kubernetes,kcp"
+  name        = "talos-m03"
+  target_node = "vm-03"
+  agent       = 1
+  memory      = 4096
+  balloon     = 2048
+  # sockets         = 1
+  cores = 4
+  tags  = "kubernetes,kcp"
 
-    disks {
-      scsi {
-        scsi0 {
-          disk { # Root Disk
-            size        = "20G"
-            storage     = "nas-vdisk"
-          }
-        }
-        scsi1 {
-          disk { # Storage Disk
-            size        = "100G"
-            storage     = "nas-vdisk"
-          }
+  disks {
+    scsi {
+      scsi0 {
+        disk { # Root Disk
+          size    = "20G"
+          storage = "nas-vdisk"
         }
       }
-      ide {
-        ide2 {
-          cdrom {
-            iso = "nas-isos:iso/talos-metal-amd64.iso"
-          }
+      scsi1 {
+        disk { # Storage Disk
+          size    = "100G"
+          storage = "nas-vdisk"
         }
       }
     }
-
-    network { # Primary Interface
-        id          = 0
-        model       = "virtio"
-        bridge      = "vmbr0"
-        firewall    = true
+    ide {
+      ide2 {
+        cdrom {
+          iso = "nas-isos:iso/talos-metal-amd64.iso"
+        }
+      }
     }
+  }
+
+  network { # Primary Interface
+    id       = 0
+    model    = "virtio"
+    bridge   = "vmbr0"
+    firewall = true
+  }
 }
 
 # Worker 01
 resource "proxmox_vm_qemu" "talos-w01" {
-    name            = "talos-w01"
-    target_node     = "vm-01"
-    agent           = 1
-    memory          = 2048
-    balloon         = 2048
-    # sockets         = 1
-    cores           = 2
-    tags            = "kubernetes,kw"
+  name        = "talos-w01"
+  target_node = "vm-01"
+  agent       = 1
+  memory      = 2048
+  balloon     = 2048
+  # sockets         = 1
+  cores = 2
+  tags  = "kubernetes,kw"
 
-    disks {
-      scsi {
-        scsi0 {
-          disk { # Root Disk
-            size        = "20G"
-            storage     = "nas-vdisk"
-          }
-        }
-        scsi1 {
-          disk { # Storage Disk
-            size        = "100G"
-            storage     = "nas-vdisk"
-          }
+  disks {
+    scsi {
+      scsi0 {
+        disk { # Root Disk
+          size    = "20G"
+          storage = "nas-vdisk"
         }
       }
-      ide {
-        ide2 {
-          cdrom {
-            iso = "nas-isos:iso/talos-metal-amd64.iso"
-          }
+      scsi1 {
+        disk { # Storage Disk
+          size    = "100G"
+          storage = "nas-vdisk"
         }
       }
     }
-
-    network { # Primary Interface
-        id          = 0
-        model       = "virtio"
-        bridge      = "vmbr0"
-        firewall    = true
+    ide {
+      ide2 {
+        cdrom {
+          iso = "nas-isos:iso/talos-metal-amd64.iso"
+        }
+      }
     }
+  }
+
+  network { # Primary Interface
+    id       = 0
+    model    = "virtio"
+    bridge   = "vmbr0"
+    firewall = true
+  }
 }
 
 # Worker 02
 resource "proxmox_vm_qemu" "talos-w02" {
-    name            = "talos-w02"
-    target_node     = "vm-01" # Set to 'vm-01' while 'vm-02' is in hibernation
-    agent           = 1
-    memory          = 2048
-    balloon         = 2048
-    # sockets         = 1
-    cores           = 2
-    tags            = "kubernetes,kw"
+  name        = "talos-w02"
+  target_node = "vm-01" # Set to 'vm-01' while 'vm-02' is in hibernation
+  agent       = 1
+  memory      = 2048
+  balloon     = 2048
+  # sockets         = 1
+  cores = 2
+  tags  = "kubernetes,kw"
 
-    disks {
-      scsi {
-        scsi0 {
-          disk { # Root Disk
-            size        = "20G"
-            storage     = "nas-vdisk"
-          }
-        }
-        scsi1 {
-          disk { # Storage Disk
-            size        = "100G"
-            storage     = "nas-vdisk"
-          }
+  disks {
+    scsi {
+      scsi0 {
+        disk { # Root Disk
+          size    = "20G"
+          storage = "nas-vdisk"
         }
       }
-      ide {
-        ide2 {
-          cdrom {
-            iso = "nas-isos:iso/talos-metal-amd64.iso"
-          }
+      scsi1 {
+        disk { # Storage Disk
+          size    = "100G"
+          storage = "nas-vdisk"
         }
       }
     }
-
-    network { # Primary Interface
-        id          = 0
-        model       = "virtio"
-        bridge      = "vmbr0"
-        firewall    = true
+    ide {
+      ide2 {
+        cdrom {
+          iso = "nas-isos:iso/talos-metal-amd64.iso"
+        }
+      }
     }
+  }
+
+  network { # Primary Interface
+    id       = 0
+    model    = "virtio"
+    bridge   = "vmbr0"
+    firewall = true
+  }
 }
 
 # Worker 03
 resource "proxmox_vm_qemu" "talos-w03" {
-    name            = "talos-w03"
-    target_node     = "vm-03"
-    agent           = 1
-    memory          = 2048
-    balloon         = 2048
-    # sockets         = 1
-    cores           = 2
-    tags            = "kubernetes,kw"
+  name        = "talos-w03"
+  target_node = "vm-03"
+  agent       = 1
+  memory      = 2048
+  balloon     = 2048
+  # sockets         = 1
+  cores = 2
+  tags  = "kubernetes,kw"
 
-    disks {
-      scsi {
-        scsi0 {
-          disk { # Root Disk
-            size        = "20G"
-            storage     = "nas-vdisk"
-          }
-        }
-        scsi1 {
-          disk { # Storage Disk
-            size        = "100G"
-            storage     = "nas-vdisk"
-          }
+  disks {
+    scsi {
+      scsi0 {
+        disk { # Root Disk
+          size    = "20G"
+          storage = "nas-vdisk"
         }
       }
-      ide {
-        ide2 {
-          cdrom {
-            iso = "nas-isos:iso/talos-metal-amd64.iso"
-          }
+      scsi1 {
+        disk { # Storage Disk
+          size    = "100G"
+          storage = "nas-vdisk"
         }
       }
     }
-
-    network { # Primary Interface
-        id          = 0
-        model       = "virtio"
-        bridge      = "vmbr0"
-        firewall    = true
+    ide {
+      ide2 {
+        cdrom {
+          iso = "nas-isos:iso/talos-metal-amd64.iso"
+        }
+      }
     }
+  }
+
+  network { # Primary Interface
+    id       = 0
+    model    = "virtio"
+    bridge   = "vmbr0"
+    firewall = true
+  }
 }
 
 ### LXC Containers

--- a/home-lab/tfvars/example.exampletfvars
+++ b/home-lab/tfvars/example.exampletfvars
@@ -1,0 +1,4 @@
+proxmox_api_url = "https://192.168.1.120:8006/api2/json"
+pm_api_token_id = "terraform-prov@pve!terraform-prov"
+pm_tls_insecure = true
+iso             = "nas-isos:iso/talos-metal-amd64.iso"


### PR DESCRIPTION
1. chore: apply terraform basic formatting
  Using `terraform fmt ./**` at the root of this project will automatically apply Terraform's default formatting. You can customize at your will, but I am just applying the basics.
3. feat: refactor proxmox configuration and add variable support
    I will have to edit real code files and have a diff against the main to deploy this to my cluster, which will cause me grief. So I wanted to variable out the basic items so I can get it going without having to have a diff. To use the new variables please create your own var file in the tfvars directory and the use the associated plan and apply commands with the -var-file=filename flag and your config file